### PR TITLE
Fixes #18455 - Read roles from Ansible roles_path

### DIFF
--- a/lib/smart_proxy_ansible/api.rb
+++ b/lib/smart_proxy_ansible/api.rb
@@ -2,12 +2,14 @@ module Proxy
   module Ansible
     class Api < Sinatra::Base
       get '/roles' do
-        `ls /etc/ansible/roles/`.split("\n").to_json
+        ForemanAnsibleCore::RolesReader.list_roles.to_json
       end
 
       get '/roles/:role_name/variables' do |role_name|
         # not anything matching item, }}, {{, ansible_hostname or 'if'
-        role_files = Dir.glob("/etc/ansible/roles/#{role_name}/**/*.yml")
+        ansible_config = '/etc/ansible/ansible.cfg'
+        roles_path = ForemanAnsibleCore::RolesReader.roles_path(ansible_config)
+        role_files = Dir.glob("#{roles_path}/#{role_name}/**/*.yml")
         variables = role_files.map do |role_file|
           File.read(role_file).scan(/{{(.*?)}}/).select do |param|
             param.first.scan(/item/) == [] && param.first.scan(/if/) == []


### PR DESCRIPTION
Reuse ForemanAnsibleCore roles method to read all roles from the
Ansible roles_path.

Relies on https://github.com/theforeman/foreman_ansible/pull/77 to be merged first