### PR TITLE
Fixes #26213 - fix 'Settings not initalized'

### DIFF
--- a/lib/smart_proxy_ansible/plugin.rb
+++ b/lib/smart_proxy_ansible/plugin.rb
@@ -9,6 +9,17 @@ module Proxy
 
       settings_file 'ansible.yml'
       plugin :ansible, Proxy::Ansible::VERSION
+
+      after_activation do
+        begin
+          require 'smart_proxy_dynflow_core'
+          require 'foreman_ansible_core'
+          ForemanAnsibleCore.initialize_settings(Proxy::Ansible::Plugin.settings.to_h)
+        rescue LoadError => _
+          # Dynflow core is not available in the proxy, will be handled
+          # by standalone Dynflow core
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Commit a5a1203cbf8 removed code that was crucial for using
foreman_ansible without smart_proxy_dynflow_core. This commit puts it
back so that devel setup (and potentially Debian) still work.