### PR TITLE
Fixes #30249 - allow collection roles to be imported

### DIFF
--- a/lib/smart_proxy_ansible/api.rb
+++ b/lib/smart_proxy_ansible/api.rb
@@ -36,11 +36,16 @@ module Proxy
 
       def extract_variables(role_name)
         variables = {}
-        RolesReader.roles_path.split(':').each do |path|
-          role_path = "#{path}/#{role_name}"
-          if File.directory?(role_path)
+        role_name_parts = role_name.split('.')
+        if role_name_parts.count == 3
+          RolesReader.collections_paths.split(':').each do |path|
             variables[role_name] ||= VariablesExtractor
-                                     .extract_variables(role_path)
+                                   .extract_variables("#{path}/ansible_collections/#{role_name_parts[0]}/#{role_name_parts[1]}/roles/#{role_name_parts[2]}")
+          end
+        else
+          RolesReader.roles_path.split(':').each do |path|
+            variables[role_name] ||= VariablesExtractor
+                                   .extract_variables("#{path}/#{role_name}")
           end
         end
         variables

--- a/lib/smart_proxy_ansible/roles_reader.rb
+++ b/lib/smart_proxy_ansible/roles_reader.rb
@@ -7,20 +7,32 @@ module Proxy
       class << self
         DEFAULT_CONFIG_FILE = '/etc/ansible/ansible.cfg'.freeze
         DEFAULT_ROLES_PATH = '/etc/ansible/roles:/usr/share/ansible/roles'.freeze
+        DEFAULT_COLLECTIONS_PATHS = '/etc/ansible/collections:/usr/share/ansible/collections'.freeze
 
         def list_roles
-          roles_path.split(':').map { |path| read_roles(path) }.flatten
+          roles = roles_path.split(':').map { |path| read_roles(path) }.flatten
+          collection_roles = collections_paths.split(':').map { |path| read_collection_roles(path) }.flatten
+          roles + collection_roles
         end
 
-        def roles_path(roles_line = roles_path_from_config)
+        def roles_path
+          config_path('roles_path',DEFAULT_ROLES_PATH)
+        end
+
+        def collections_paths
+          config_path('collections_paths',DEFAULT_COLLECTIONS_PATHS)
+        end
+
+        def config_path(config_key,default)
+          config_line=path_from_config(config_key)
           # Default to /etc/ansible/roles if none found
-          return DEFAULT_ROLES_PATH if roles_line.empty?
-          roles_path_key = roles_line.first.split('=').first.strip
+          return default if config_line.empty?
+          config_line_key = config_line.first.split('=').first.strip
           # In case of commented roles_path key "#roles_path", return default
-          return DEFAULT_ROLES_PATH unless roles_path_key == 'roles_path'
-          roles_line.first.split('=').last.strip
+          return default unless config_line_key == config_key
+          config_line.first.split('=').last.strip
         end
-
+        
         def logger
           # Return a different logger depending on where ForemanAnsibleCore is
           # running from
@@ -42,11 +54,25 @@ module Proxy
           end
         end
 
-        def roles_path_from_config
+        def read_collection_roles(collections_path)
+          rescue_and_raise_file_exception ReadRolesException,
+                                          collections_path, 'roles' do
+            Dir.glob("#{collections_path}/ansible_collections/*/*/roles/*").map do |path|
+              parts = path.split('/')
+              role = parts.pop
+              parts.pop
+              collection = parts.pop
+              author = parts.pop
+              "#{author}.#{collection}.#{role}" 
+            end
+          end
+        end
+
+        def path_from_config(config_key)
           rescue_and_raise_file_exception ReadConfigFileException,
                                           DEFAULT_CONFIG_FILE, 'config file' do
             File.readlines(DEFAULT_CONFIG_FILE).select do |line|
-              line =~ /^\s*roles_path/
+              line =~ /^\s*#{config_key}/
             end
           end
         end


### PR DESCRIPTION
This Patch allows to import roles that are part of collections. It also imports the variables of these roles.