### PR TITLE
Update development dependencies

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,10 @@
 require 'rake'
 require 'rake/testtask'
-require 'bundler/gem_tasks'
+
+begin
+  require 'bundler/gem_tasks'
+rescue LoadError
+end
 
 desc 'Default: run unit tests.'
 task default: :test
@@ -12,12 +16,4 @@ Rake::TestTask.new(:test) do |t|
   t.libs << 'test'
   t.test_files = FileList['test/**/*_test.rb']
   t.verbose = true
-end
-
-require 'rubocop/rake_task'
-
-desc 'Run RuboCop on the lib directory'
-RuboCop::RakeTask.new(:rubocop) do |task|
-  task.patterns = ['lib/**/*.rb', 'test/**/*.rb']
-  task.fail_on_error = false
 end

--- a/smart_proxy_ansible.gemspec
+++ b/smart_proxy_ansible.gemspec
@@ -24,12 +24,11 @@ Gem::Specification.new do |gem|
   gem.require_paths    = ['lib']
   gem.license = 'GPL-3.0'
 
-  gem.add_development_dependency 'rake', '~> 10.0'
+  gem.add_development_dependency 'rake', '~> 13.0'
   gem.add_development_dependency('minitest', '~> 0')
   gem.add_development_dependency('mocha', '~> 1')
-  gem.add_development_dependency('webmock', '~> 1')
+  gem.add_development_dependency('webmock', '~> 3')
   gem.add_development_dependency('rack-test', '~> 0')
-  gem.add_development_dependency('rubocop', '0.32.1')
   gem.add_development_dependency('logger')
   gem.add_development_dependency('smart_proxy')
   gem.add_runtime_dependency('smart_proxy_dynflow', '~> 0.1')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,5 @@
-require 'minitest/spec'
 require 'minitest/autorun'
+require 'minitest/spec'
 require 'mocha/minitest'
 require 'smart_proxy_for_testing'
 


### PR DESCRIPTION
This updates dependencies to avoid CVEs in Bundler and Rubocop. Rubocop is dropped since it didn't ran and the version was incompatible with a recent Rake. Thus needs a much bigger effort.

The bundler tasks are allowed not to be present, which allows Bundler 2 to be installed as well.