### PR TITLE
Use rackup_path as introduced in Foreman Proxy 2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Proxy plugin to make [foreman_ansible](https://github.com/theforeman/foreman_ansible) actions run in the proxy
 
+## Compatibility
+
+This plugin requires at least Foreman Proxy 2.3.
+
 ## Installation (in development)
 
 ### Prerequisites

--- a/lib/smart_proxy_ansible/plugin.rb
+++ b/lib/smart_proxy_ansible/plugin.rb
@@ -2,11 +2,7 @@ module Proxy
   module Ansible
     # Calls for the smart-proxy API to register the plugin
     class Plugin < Proxy::Plugin
-      http_rackup_path File.expand_path('http_config.ru',
-                                        File.expand_path('../', __FILE__))
-      https_rackup_path File.expand_path('http_config.ru',
-                                         File.expand_path('../', __FILE__))
-
+      rackup_path File.expand_path('http_config.ru', __dir__)
       settings_file 'ansible.yml'
       plugin :ansible, Proxy::Ansible::VERSION
 


### PR DESCRIPTION
`rackup_path` does the same as calling both `http_rackup_path` and `https_rackup_path`. It also uses the `__dir__` shorthand.