### PR TITLE
Use shorter syntax for rescue blocks

### DIFF
--- a/lib/smart_proxy_ansible/api.rb
+++ b/lib/smart_proxy_ansible/api.rb
@@ -13,23 +13,19 @@ module Proxy
       get '/roles/variables' do
         variables = {}
         RolesReader.list_roles.each do |role_name|
-          begin
-            variables[role_name] = extract_variables(role_name)[role_name]
-          rescue ReadVariablesException => e
-            # skip what cannot be parsed
-            logger.error e
-          end
+          variables.merge!(extract_variables(role_name))
+        rescue ReadVariablesException => e
+          # skip what cannot be parsed
+          logger.error e
         end
         variables.to_json
       end
 
       get '/roles/:role_name/variables' do |role_name|
-        begin
-          extract_variables(role_name).to_json
-        rescue ReadVariablesException => e
-          logger.error e
-          {}.to_json
-        end
+        extract_variables(role_name).to_json
+      rescue ReadVariablesException => e
+        logger.error e
+        {}.to_json
       end
 
       private

--- a/smart_proxy_ansible.gemspec
+++ b/smart_proxy_ansible.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
   gem.test_files       = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths    = ['lib']
   gem.license = 'GPL-3.0'
+  gem.required_ruby_version = '>= 2.5'
 
   gem.add_development_dependency 'rake', '~> 13.0'
   gem.add_development_dependency('mocha', '~> 1')


### PR DESCRIPTION
Since Ruby 2.5 it's allowed to use rescue inside do/end blocks. This leads to shorter code.

It also removes the rescue_and_raise_file_exception method in favor of copying the error handling to each function. This ends up being shorter and easier to understand.