### PR TITLE
Fixes #24367 - add support for passphrased keys

### DIFF
--- a/lib/smart_proxy_ansible/runner/ansible_runner.rb
+++ b/lib/smart_proxy_ansible/runner/ansible_runner.rb
@@ -1,4 +1,5 @@
 require 'shellwords'
+require 'yaml'
 
 require 'smart_proxy_dynflow/runner/command'
 require 'smart_proxy_dynflow/runner/base'
@@ -19,12 +20,14 @@ module Proxy::Ansible
         @check_mode = action_input[:check_mode]
         @tags = action_input[:tags]
         @tags_flag = action_input[:tags_flag]
+        @passphrase = action_input['secrets']['key_passphrase']
       end
 
       def start
         prepare_directory_structure
         write_inventory
         write_playbook
+        write_ssh_key if !@passphrase.nil? && !@passphrase.empty?
         start_ansible_runner
       end
 
@@ -111,6 +114,19 @@ module Proxy::Ansible
         File.write(File.join(@root, 'project', 'playbook.yml'), @playbook)
       end
 
+      def write_ssh_key
+        key_path = File.join(@root, 'env', 'ssh_key')
+        File.symlink(File.expand_path(ForemanRemoteExecutionCore.settings[:ssh_identity_key_file]), key_path)
+
+        passwords_path = File.join(@root, 'env', 'passwords')
+        # here we create a secrets file for ansible-runner, which uses the key as regexp
+        # to match line asking for password, given the limitation to match only first 100 chars
+        # and the fact the line contains dynamically created temp directory, the regexp
+        # mentions only things that are always there, such as artifacts directory and the key name
+        secrets = YAML.dump({ "for.*/artifacts/.*/ssh_key_data:" => @passphrase })
+        File.write(passwords_path, secrets, perm: 0o600)
+      end
+
       def start_ansible_runner
         env = {}
         env['FOREMAN_CALLBACK_DISABLE'] = '1' if @rex_command
@@ -149,7 +165,7 @@ module Proxy::Ansible
       end
 
       def prepare_directory_structure
-        inner = %w[inventory project].map { |part| File.join(@root, part) }
+        inner = %w[inventory project env].map { |part| File.join(@root, part) }
         ([@root] + inner).each do |path|
           FileUtils.mkdir_p path
         end


### PR DESCRIPTION
SSH keys protected by the passphrase is not possible to use with pure
Ansible. However ansible-runner provides a way to specify the password
through env/passwords file. For that, the ssh key also needs to be
placed under env/ssh_key (symlink is enough). We already have a
passphrase field in REX Job invocation object, but until now we ignored
that in Ansible jobs.

This patch starts respecting the passphrase for Ansible jobs too. First
it parses the passphrase from the action input. During the
ansible-runner directory preparation, it also creates the env directory.
It symlinks the foreman-proxy key in there and if a passphrase was
specified for the Job invocation, it saves it into the env/passwords
file.

The ansible-runner limitation of a single key means, we can not support
multiple keys with multiple passphrases stored as Host Parameters. The
feature supports only the passphrase specified on the job level, the
same applies to the SSH key. The ansible-runner secrets is only used, if
the passphrase is specified for the job.

Ansible-runner has a bug that we can't easily specify the env/passwords
entry for the ssh-key. The regular expression is only matched with last
100 characters of the line. We can use '^Enter' in the regexp for that
reason. Also the prompt typically contain the full path to the private
key, which is always dynamic. Therefore the regular expression only
contains words artifacts and ssh_key_data: See
https://github.com/ansible/ansible-runner/issues/533 for more details.
The functionality is documented at

* https://ansible-runner.readthedocs.io/en/stable/intro.html#env-ssh-key
* https://ansible-runner.readthedocs.io/en/stable/intro.html#env-passwords