### PR TITLE
Fixes #32779 - use directly smart_proxy_dynflow

### DIFF
--- a/lib/smart_proxy_ansible/actions.rb
+++ b/lib/smart_proxy_ansible/actions.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require 'foreman_tasks_core/shareable_action'
+require 'smart_proxy_dynflow/action/runner'
 
 module Proxy::Ansible
   module Actions
     # Action that can be run both on Foreman or Foreman proxy side
     # to execute the playbook run
-    class RunPlaybook < ForemanTasksCore::Runner::Action
+    class RunPlaybook < Proxy::Dynflow::Action::Runner
       def initiate_runner
         Proxy::Ansible::Runner::Playbook.new(
           input[:inventory],

--- a/lib/smart_proxy_ansible/plugin.rb
+++ b/lib/smart_proxy_ansible/plugin.rb
@@ -9,7 +9,8 @@ module Proxy
                        # :working_dir => nil
 
       after_activation do
-        require 'foreman_tasks_core'
+        require 'smart_proxy_dynflow'
+        require 'smart_proxy_dynflow/continuous_output'
         require 'smart_proxy_ansible/task_launcher/ansible_runner'
         require 'smart_proxy_ansible/task_launcher/playbook'
         require 'smart_proxy_ansible/actions'
@@ -18,9 +19,9 @@ module Proxy
         require 'smart_proxy_ansible/runner/command_creator'
         require 'smart_proxy_ansible/runner/playbook'
 
-        SmartProxyDynflowCore::TaskLauncherRegistry.register('ansible-runner',
+        Proxy::Dynflow::TaskLauncherRegistry.register('ansible-runner',
           TaskLauncher::AnsibleRunner)
-        SmartProxyDynflowCore::TaskLauncherRegistry.register('ansible-playbook',
+        Proxy::Dynflow::TaskLauncherRegistry.register('ansible-playbook',
           TaskLauncher::Playbook)
       end
     end

--- a/lib/smart_proxy_ansible/remote_execution_core/ansible_runner.rb
+++ b/lib/smart_proxy_ansible/remote_execution_core/ansible_runner.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+require 'smart_proxy_dynflow/runner/command_runner'
+
 module Proxy::Ansible
   module RemoteExecutionCore
     # Takes an inventory and runs it through REXCore CommandRunner
-    class AnsibleRunner < ::ForemanTasksCore::Runner::CommandRunner
+    class AnsibleRunner < ::Proxy::Dynflow::Runner::CommandRunner
       DEFAULT_REFRESH_INTERVAL = 1
       CONNECTION_PROMPT = 'Are you sure you want to continue connecting (yes/no)? '
 

--- a/lib/smart_proxy_ansible/runner/ansible_runner.rb
+++ b/lib/smart_proxy_ansible/runner/ansible_runner.rb
@@ -1,10 +1,12 @@
 require 'shellwords'
 
-require 'foreman_tasks_core/runner/command_runner'
+require 'smart_proxy_dynflow/runner/command'
+require 'smart_proxy_dynflow/runner/base'
+require 'smart_proxy_dynflow/runner/parent'
 module Proxy::Ansible
   module Runner
-    class AnsibleRunner < ForemanTasksCore::Runner::Parent
-      include ForemanTasksCore::Runner::Command
+    class AnsibleRunner < ::Proxy::Dynflow::Runner::Parent
+      include ::Proxy::Dynflow::Runner::Command
 
       def initialize(input, suspended_action:)
         super input, :suspended_action => suspended_action

--- a/lib/smart_proxy_ansible/runner/command_creator.rb
+++ b/lib/smart_proxy_ansible/runner/command_creator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Proxy::Ansible
-  # Creates the actual command to be passed to foreman_tasks_core to run
+  # Creates the actual command to be passed to smart_proxy_dynflow to run
   class CommandCreator
     def initialize(inventory_file, playbook_file, options = {})
       @options = options

--- a/lib/smart_proxy_ansible/runner/playbook.rb
+++ b/lib/smart_proxy_ansible/runner/playbook.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
-require 'foreman_tasks_core/runner/command_runner'
+require 'smart_proxy_dynflow/continuous_output'
+require 'smart_proxy_dynflow/runner/command_runner'
 require_relative 'command_creator'
 require 'tmpdir'
 require 'net/ssh'
 
 module Proxy::Ansible
   module Runner
-    # Implements ForemanTasksCore::Runner::Base interface for running
+    # Implements Proxy::Dynflow::Runner::Base interface for running
     # Ansible playbooks, used by the Foreman Ansible plugin and Ansible proxy
-    class Playbook < ForemanTasksCore::Runner::CommandRunner
+    class Playbook < Proxy::Dynflow::Runner::CommandRunner
       attr_reader :command_out, :command_in, :command_pid
 
       def initialize(inventory, playbook, options = {}, suspended_action:)

--- a/lib/smart_proxy_ansible/task_launcher/ansible_runner.rb
+++ b/lib/smart_proxy_ansible/task_launcher/ansible_runner.rb
@@ -1,9 +1,12 @@
 require 'fileutils'
+require 'smart_proxy_dynflow/task_launcher/abstract'
+require 'smart_proxy_dynflow/task_launcher/batch'
+require 'smart_proxy_dynflow/task_launcher/group'
 require 'smart_proxy_ansible/runner/ansible_runner'
 
 module Proxy::Ansible
   module TaskLauncher
-    class AnsibleRunner < ForemanTasksCore::TaskLauncher::AbstractGroup
+    class AnsibleRunner < Proxy::Dynflow::TaskLauncher::AbstractGroup
       def runner_input(input)
         super(input).reduce({}) do |acc, (_id, data)|
           acc.merge(data[:input]['action_input']['name'] => data)

--- a/lib/smart_proxy_ansible/task_launcher/playbook.rb
+++ b/lib/smart_proxy_ansible/task_launcher/playbook.rb
@@ -1,7 +1,9 @@
+require 'smart_proxy_dynflow/action/runner'
+
 module Proxy::Ansible
   module TaskLauncher
-    class Playbook < ForemanTasksCore::TaskLauncher::Batch
-      class PlaybookRunnerAction < ForemanTasksCore::Runner::Action
+    class Playbook < Proxy::Dynflow::TaskLauncher::Batch
+      class PlaybookRunnerAction < Proxy::Dynflow::Action::Runner
         def initiate_runner
           additional_options = {
             :step_id => run_step_id,
@@ -15,7 +17,7 @@ module Proxy::Ansible
       end
 
       def child_launcher(parent)
-        ForemanTasksCore::TaskLauncher::Single.new(world, callback, :parent => parent,
+        ::Proxy::Dynflow::TaskLauncher::Single.new(world, callback, :parent => parent,
                                                                     :action_class_override => PlaybookRunnerAction)
       end
     end

--- a/smart_proxy_ansible.gemspec
+++ b/smart_proxy_ansible.gemspec
@@ -31,8 +31,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('rack-test', '~> 0')
   gem.add_development_dependency('logger')
   gem.add_development_dependency('smart_proxy')
-  gem.add_runtime_dependency('foreman-tasks-core', '~> 0.3.2')
   gem.add_runtime_dependency('net-ssh')
-  gem.add_runtime_dependency('smart_proxy_dynflow', '~> 0.1')
+  gem.add_runtime_dependency('smart_proxy_dynflow', '~> 0.5')
   gem.add_runtime_dependency('smart_proxy_remote_execution_ssh', '~> 0.4')
 end

--- a/test/ansible_runner_test.rb
+++ b/test/ansible_runner_test.rb
@@ -2,8 +2,6 @@
 
 require 'test_helper'
 require 'smart_proxy_ansible'
-require 'foreman_tasks_core'
-require 'foreman_tasks_core/runner/command'
 require 'smart_proxy_ansible/runner/ansible_runner'
 
 module Proxy::Ansible

--- a/test/playbook_runner_test.rb
+++ b/test/playbook_runner_test.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-require 'foreman_tasks_core'
+require 'smart_proxy_dynflow'
 require 'smart_proxy_ansible'
 
-# Playbook Runner - this class uses foreman_tasks_core
+# Playbook Runner - this class uses smart_proxy_dynflow
 # to run playbooks
 class PlaybookRunnerTest < Minitest::Test
   describe 'PlaybookRunner' do


### PR DESCRIPTION
The ForemanTasksCore has been discontinued and has been moved to
smart_proxy_dynflow. We should use those classes directly and not rely
on the compatibility layer tasks_core gem.