### PR TITLE
Fixes #32775 - use directly smart_proxy_rex_ssh

### DIFF
--- a/lib/smart_proxy_ansible/runner/ansible_runner.rb
+++ b/lib/smart_proxy_ansible/runner/ansible_runner.rb
@@ -168,7 +168,7 @@ module Proxy::Ansible
         inventories = action_inputs.map { |hash| hash[:ansible_inventory] }
         host_vars = inventories.map { |i| i['_meta']['hostvars'] }.reduce({}) do |acc, hosts|
           hosts.reduce(acc) do |inner_acc, (hostname, vars)|
-            vars[:ansible_ssh_private_key_file] ||= ForemanRemoteExecutionCore.settings[:ssh_identity_key_file]
+            vars[:ansible_ssh_private_key_file] ||= Proxy::RemoteExecution::Ssh::Plugin.settings[:ssh_identity_key_file]
             inner_acc.merge(hostname => vars)
           end
         end

--- a/smart_proxy_ansible.gemspec
+++ b/smart_proxy_ansible.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('logger')
   gem.add_development_dependency('smart_proxy')
   gem.add_runtime_dependency('foreman-tasks-core', '~> 0.3.2')
-  gem.add_runtime_dependency('foreman_remote_execution_core', '~> 1.1')
   gem.add_runtime_dependency('net-ssh')
   gem.add_runtime_dependency('smart_proxy_dynflow', '~> 0.1')
+  gem.add_runtime_dependency('smart_proxy_remote_execution_ssh', '~> 0.4')
 end


### PR DESCRIPTION
The ForemanRemoteExecution has been discontinued and has been moved to
smart_proxy_remote_execution_ssh. We should use those classes directly
and not rely on the compatibility layer rex_core gem.