### PR TITLE
Fixes #32796 - Return the correct exit code for the rescued task

### DIFF
--- a/lib/smart_proxy_ansible/runner/ansible_runner.rb
+++ b/lib/smart_proxy_ansible/runner/ansible_runner.rb
@@ -83,10 +83,16 @@ module Proxy::Ansible
       def handle_broadcast_data(event)
         log_event("broadcast", event)
         if event['event'] == 'playbook_on_stats'
+          failures = event.dig('event_data', 'failures') || {}
           header, *rows = event['stdout'].strip.lines.map(&:chomp)
           @outputs.keys.select { |key| key.is_a? String }.each do |host|
             line = rows.find { |row| row =~ /#{host}/ }
             publish_data_for(host, [header, line].join("\n"), 'stdout')
+
+            # If the task has been rescued, it won't consider a failure
+            if @exit_statuses[host].to_i != 0 && failures[host].to_i <= 0
+              publish_exit_status_for(host, 0)
+            end
           end
         else
           broadcast_data(event['stdout'] + "\n", 'stdout')


### PR DESCRIPTION
Ansible runner will raise the "runner_on_failed" event even the task has been rescued. This is causing the host job to exit with a non zero exit code. This commit fixed the issue by checking the "failures" fields in the "playbook_on_stats" event data.