### PR TITLE
Fixes #31489 - Updating path to ansible.cfg file

### DIFF
--- a/lib/smart_proxy_ansible/roles_reader.rb
+++ b/lib/smart_proxy_ansible/roles_reader.rb
@@ -5,7 +5,7 @@ module Proxy
     # Implements the logic needed to read the roles and associated information
     class RolesReader
       class << self
-        DEFAULT_CONFIG_FILE = '/etc/ansible/ansible.cfg'.freeze
+        DEFAULT_CONFIG_FILE = '/etc/foreman_proxy/ansible.cfg'.freeze
         DEFAULT_ROLES_PATH = '/etc/ansible/roles:/usr/share/ansible/roles'.freeze
         DEFAULT_COLLECTIONS_PATHS = '/etc/ansible/collections:/usr/share/ansible/collections'.freeze
 


### PR DESCRIPTION
Ansible has own config file at /etc/ansible folder. Foreman uses own config file located at /etc/foreman-proxy and it causes confusing for proper configuration. This PR changes path to correct config file in default configuration scenario.