### PR TITLE
Fixes #34358 - Avoid #slice on indifferent hashes

### DIFF
--- a/lib/smart_proxy_ansible/task_launcher/ansible_runner.rb
+++ b/lib/smart_proxy_ansible/task_launcher/ansible_runner.rb
@@ -24,7 +24,8 @@ module Proxy::Ansible
       # Discard everything apart from hostname to be able to tell the actions
       # apart when debugging
       def transform_input(input)
-        { 'action_input' => super['action_input'].slice('name', :task_id) }
+        action_input = super['action_input']
+        { 'action_input' => { 'name' => action_input['name'], :task_id => action_input[:task_id] } }
       end
 
       # def self.input_format


### PR DESCRIPTION
This could lead to :task_id key not being present in input being passed to
OutputCollector. In turn, OutputCollector would generate a random value for it
and then Foreman's side couldn't match the action when trying to view live
output
