### PR TITLE
Fixes #35049 - Correctly treat syntax errors as errors

### DIFF
--- a/lib/smart_proxy_ansible/runner/ansible_runner.rb
+++ b/lib/smart_proxy_ansible/runner/ansible_runner.rb
@@ -65,6 +65,7 @@ module Proxy::Ansible
       def publish_exit_status(status)
         process_artifacts
         super
+        @targets.each_key { |host| publish_exit_status_for(host, status) } if status != 0
       end
 
       def initialize_command(*command)


### PR DESCRIPTION
This is done by overriding per-host exit statuses with an exit status of
the main process, if the main process indicates a failure.