### PR TITLE
Fixes #34605 - allow working without ansible.cfg

### DIFF
--- a/lib/smart_proxy_ansible/reader_helper.rb
+++ b/lib/smart_proxy_ansible/reader_helper.rb
@@ -25,9 +25,9 @@ module Proxy
             line =~ /^\s*#{config_key}/
           end
         rescue Errno::ENOENT, Errno::EACCES => e
-          RolesReader.logger.debug(e.backtrace)
-          message = "Could not read Ansible config file #{DEFAULT_CONFIG_FILE} - #{e.message}"
-          raise ReadConfigFileException.new(message), message
+          message = "Could not read Ansible config file #{DEFAULT_CONFIG_FILE}, using defaults - #{e.message}"
+          RolesReader.logger.info(message)
+          []
         end
 
         def playbook_or_role_full_name(path)

--- a/test/roles_reader_test.rb
+++ b/test/roles_reader_test.rb
@@ -89,20 +89,30 @@ class RolesReaderTest < Minitest::Test
     end
 
     describe 'with unreadable config' do
-      test 'handles "No such file or dir" with exception' do
-        File.expects(:readlines).with(CONFIG_PATH).raises(Errno::ENOENT)
-        ex = assert_raises(Proxy::Ansible::ReadConfigFileException) do
-          Proxy::Ansible::RolesReader.list_roles
+      test 'handles "No such file or directory" by using defaults' do
+        File.expects(:readlines).times(2).with(CONFIG_PATH).raises(Errno::ENOENT)
+
+        ROLES_PATH.split(':').map do |path|
+          Proxy::Ansible::RolesReader.expects(:read_roles).with(path)
         end
-        assert_match(/Could not read Ansible config file/, ex.message)
+        COLLECTIONS_PATHS.split(':').map do |path|
+          Proxy::Ansible::RolesReader.expects(:read_collection_roles).with(path)
+        end
+
+        Proxy::Ansible::RolesReader.list_roles
       end
 
-      test 'raises error if the roles path is not readable' do
-        File.expects(:readlines).with(CONFIG_PATH).raises(Errno::EACCES)
-        ex = assert_raises(Proxy::Ansible::ReadConfigFileException) do
-          Proxy::Ansible::RolesReader.list_roles
+      test 'handles "Permission denied" by using defaults' do
+        File.expects(:readlines).times(2).with(CONFIG_PATH).raises(Errno::EACCES)
+
+        ROLES_PATH.split(':').map do |path|
+          Proxy::Ansible::RolesReader.expects(:read_roles).with(path)
         end
-        assert_match(/Could not read Ansible config file/, ex.message)
+        COLLECTIONS_PATHS.split(':').map do |path|
+          Proxy::Ansible::RolesReader.expects(:read_collection_roles).with(path)
+        end
+
+        Proxy::Ansible::RolesReader.list_roles
       end
     end
   end


### PR DESCRIPTION
It's perfectly OK for a system not to have an `/etc/ansible/ansible.cfg` file and our configuration loader should honor that and fall back to defaults instead of raising an exception.