### PR TITLE
Refs #36130 - Update code for compatibility with Ansible 2.12.2

### DIFF
--- a/lib/smart_proxy_ansible/runner/ansible_runner.rb
+++ b/lib/smart_proxy_ansible/runner/ansible_runner.rb
@@ -143,13 +143,14 @@ module Proxy::Ansible
         if event['event'] == 'playbook_on_stats'
           failures = event.dig('event_data', 'failures') || {}
           unreachable = event.dig('event_data', 'dark') || {}
+          rescued = event.dig('event_data', 'rescued') || {}
           header, *rows = event['stdout'].strip.lines.map(&:chomp)
           @outputs.keys.select { |key| key.is_a? String }.each do |host|
             line = rows.find { |row| row =~ /#{host}/ }
             publish_data_for(host, [header, line].join("\n"), 'stdout')
 
             # If the task has been rescued, it won't consider a failure
-            if @exit_statuses[host].to_i != 0 && failures[host].to_i <= 0 && unreachable[host].to_i <= 0
+            if @exit_statuses[host].to_i != 0 && failures[host].to_i <= 0 && unreachable[host].to_i <= 0 && rescued[host].to_i > 0
               publish_exit_status_for(host, 0)
             end
           end


### PR DESCRIPTION
Set the exit status to success only for rescued tasks.