### PR TITLE
Fixes #36448 - fix ignored passwords in Job Template

### DIFF
--- a/lib/smart_proxy_ansible/runner/ansible_runner.rb
+++ b/lib/smart_proxy_ansible/runner/ansible_runner.rb
@@ -276,8 +276,8 @@ module Proxy::Ansible
           per_host = secrets['per-host'][host]
 
           new_secrets = {
-            'ansible_password' => inventory['ssh_password'] || per_host['ansible_password'],
-            'ansible_become_password' => inventory['effective_user_password'] || per_host['ansible_become_password']
+            'ansible_password' => secrets['ssh_password'] || per_host['ansible_password'],
+            'ansible_become_password' => secrets['effective_user_password'] || per_host['ansible_become_password']
           }
           inventory['all']['hosts'][host].update(new_secrets)
         end


### PR DESCRIPTION
Previously, the provided values for the "SSH password" and the "Effective user password" in the Advanced Fields of the Job Template were being ignored. This PR addresses the issue by correctly processing and utilizing these values.