### PR TITLE
Fixes #TBFL - Allow viewing of the entire output at once

### DIFF
--- a/lib/smart_proxy_ansible/runner/ansible_runner.rb
+++ b/lib/smart_proxy_ansible/runner/ansible_runner.rb
@@ -286,6 +286,12 @@ module Proxy::Ansible
 
         inventory
       end
+
+      def publish_data_for(hostname, content, type)
+        @outputs.each_key do |peer_hostname, _|
+          super(peer_hostname, content, peer_hostname == hostname ? type : 'debug')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Prompted by [community.theforeman.org/t/output-of-the-job-execution-is-inconsistent](https://community.theforeman.org/t/output-of-the-job-execution-is-inconsistent/38778?u=aruzicka)

For before see screenshots in https://github.com/theforeman/smart_proxy_ansible/pull/91


Under the hood, all the outputs are logged to all the hosts, but they are treated as debug if they don't really belong to the host in question. Then in the webui, these can be filtered out.

I'm opening this as a draft for now until we figure out if this is something we want as this is a best effort solution at best.

Pros:
- provides additional context
- provides additional visibility into how things are actually executed and which things run together

Cons:
- the output gets stored in multiple copies on both the proxy and in foreman
- the wider output is shown by default, this could be addressed with some ansible-specific changes in foreman_ansible
- the use of debug paints the lines red, which is fixable, but not here

With debug:
![image](https://github.com/user-attachments/assets/37731d99-8b73-432d-8b92-2f2eb26e6866)

With debug filtered out:
![image](https://github.com/user-attachments/assets/1f7793a8-804c-4aec-8638-f9fb77e57a11)
