### PR TITLE
Fixes #37942 - Add job_check_mode to allow Ansible Check Mode in Job Templates

### DIFF
--- a/lib/smart_proxy_ansible/runner/ansible_runner.rb
+++ b/lib/smart_proxy_ansible/runner/ansible_runner.rb
@@ -22,6 +22,7 @@ module Proxy::Ansible
         @verbosity_level = action_input[:verbosity_level]
         @rex_command = action_input[:remote_execution_command]
         @check_mode = action_input[:check_mode]
+        @job_check_mode = action_input[:job_check_mode]
         @tags = action_input[:tags]
         @tags_flag = action_input[:tags_flag]
         @passphrase = action_input['secrets']['key_passphrase']
@@ -216,7 +217,11 @@ module Proxy::Ansible
       end
 
       def check_cmd
-        check_mode? ? '"--check"' : ''
+        if check_mode? || job_check_mode?
+          '"--check"'
+        else
+          ''
+        end
       end
 
       def verbosity
@@ -229,6 +234,10 @@ module Proxy::Ansible
 
       def check_mode?
         @check_mode == true && @rex_command == false
+      end
+
+      def job_check_mode?
+        @job_check_mode == true
       end
 
       def prepare_directory_structure

--- a/test/fixtures/action_input.json
+++ b/test/fixtures/action_input.json
@@ -91,6 +91,7 @@
     "remote_execution_command": true,
     "name": "test-00.example.com",
     "check_mode": false,
+    "job_check_mode": false,
     "hostname": "127.0.0.1",
     "script": "---\n- hosts: all\n  tasks:\n    - shell:\n        cmd: |\n          ls -la /\n      register: out\n    - debug: var=out",
     "execution_timeout_interval": null,


### PR DESCRIPTION
#### Overview of Changes
This PR adds a separate `job_check_mode` variable to the AnsibleRunner class allowing Ansible Check Mode to be set on Jobs when the new ansible_check_mode checkbox is selected in Ansible Job Templates (see PR https://github.com/theforeman/foreman_ansible/pull/742).

#### Implementation Considerations
I considered re-using the existing `check_mode` variable.  However, _its_ intended use is with the ansible_roles_check_mode host parameter executing Ansible Check Mode on the "Ansible Roles" job _only_.  Therefore, in order to not change the current expected behavior, I've separated the new functionality into a different boolean.

#### Testing Steps
1. Add the changes in https://github.com/theforeman/foreman_ansible/pull/742 to your test environment.
2. Add the changes in _this_ PR to your test environment.
3. Clone the "Ansible Roles - Ansible Default" Job Template.
4. In the clone's "Ansible" tab, select the "Ansible Check Mode Enabled" checkbox and save the Job Template.
5. On a host, schedule a Job and select the cloned Job Category and Job Template.  Execute the job.

#### Checklists

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman/blob/develop/CONTRIBUTING.md) guidelines.
* [x] I have added relevant tests for my changes.
* [x] I have updated the documentation accordingly.

#### Additional Notes
### This PR is dependent on:
* https://github.com/theforeman/foreman_ansible/pull/742