### PR TITLE
Change rake task 'verbose' parameter

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,5 +15,5 @@ Rake::TestTask.new(:test) do |t|
   t.libs << 'lib'
   t.libs << 'test'
   t.test_files = FileList['test/**/*_test.rb']
-  t.verbose = true
+  t.options = '--verbose'
 end


### PR DESCRIPTION
To work around the incompatibility between rake >=13.4.2 and ci_reporter_test_unit