### PR TITLE
refactor(inventory): write hosts.yml instead of hosts.json + Vault tag support, fixes #35171

### DIFF
--- a/lib/smart_proxy_ansible.rb
+++ b/lib/smart_proxy_ansible.rb
@@ -6,6 +6,7 @@ module Proxy
     require 'smart_proxy_ansible/version'
     require 'smart_proxy_ansible/configuration_loader'
     require 'smart_proxy_ansible/validate_settings'
+    require 'smart_proxy_ansible/vault_yaml_patch'
     require 'smart_proxy_ansible/plugin'
     require 'smart_proxy_ansible/roles_reader'
     require 'smart_proxy_ansible/playbooks_reader'

--- a/lib/smart_proxy_ansible/plugin.rb
+++ b/lib/smart_proxy_ansible/plugin.rb
@@ -5,6 +5,9 @@ module Proxy
       rackup_path File.expand_path('http_config.ru', __dir__)
       settings_file 'ansible.yml'
       plugin :ansible, Proxy::Ansible::VERSION
+      after_activation do
+        Psych::Visitors::YAMLTree.prepend(VaultYamlPatch)
+      end
       default_settings :ansible_dir => Dir.home,
                        :ansible_environment_file => '/etc/foreman-proxy/ansible.env'
                        # :working_dir => nil

--- a/lib/smart_proxy_ansible/runner/ansible_runner.rb
+++ b/lib/smart_proxy_ansible/runner/ansible_runner.rb
@@ -179,10 +179,27 @@ module Proxy::Ansible
         end
       end
 
+      def normalize_object(obj)
+        if obj.class == Dynflow::Utils::IndifferentHash
+          obj = obj.to_hash
+        end
+
+        case obj
+        when Hash
+          obj.each do |k,v|
+            obj[k] = normalize_object(v)
+          end
+        when Array
+          obj = obj.map {|el| normalize_object(el)}
+        end
+        obj
+      end
+
       def write_inventory
-        File.open(File.join(@root, 'inventory', 'hosts.json'), 'w') do |file|
+        @inventory = normalize_object(@inventory)
+        File.open(File.join(@root, 'inventory', 'hosts.yml'), 'w') do |file|
           file.chmod(0o0640)
-          file.write(JSON.dump(@inventory))
+          file.write(Psych.dump(@inventory))
         end
       end
 

--- a/lib/smart_proxy_ansible/vault_yaml_patch.rb
+++ b/lib/smart_proxy_ansible/vault_yaml_patch.rb
@@ -1,0 +1,20 @@
+require 'psych'
+module VaultYamlPatch
+  VAULT_PREFIX = /\A!vault\s*\|\n/
+
+  def visit_String(o)
+    if o.match?(VAULT_PREFIX)
+      value = o.sub(VAULT_PREFIX, '')
+      @emitter.scalar(
+        value,
+        nil,
+        "!vault",
+        false,
+        false,
+        Psych::Nodes::Scalar::LITERAL
+      )
+    else
+      super
+    end
+  end
+end

--- a/test/vault_yaml_patch_test.rb
+++ b/test/vault_yaml_patch_test.rb
@@ -1,0 +1,17 @@
+describe 'VaultYamlPatch' do
+  test 'preserves !vault tag in YAML output' do
+    vault_content = <<~VAULT
+      $ANSIBLE_VAULT;1.1;AES256
+      613239636239623865623037336261...
+    VAULT
+
+    data = {
+      'secret_var' => "!vault |\n  #{vault_content}"
+    }
+
+    yaml_output = Psych.dump(data)
+
+    assert yaml_output.include?('!vault'), "Should preserve !vault tag"
+    assert yaml_output.include?('secret_var:'), "Should contain key"
+  end
+end


### PR DESCRIPTION
- Change inventory file from hosts.json to hosts.yml
- Use Psych.dump for YAML serialization
- Add VaultYamlPatch to preserve !vault| tag in output
- Add normalize_object helper for Dynflow IndifferentHash
first step to Feature #35171 [redmine issue](https://projects.theforeman.org/issues/35171)